### PR TITLE
Issue/2132 fix scale display text

### DIFF
--- a/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCropActivity.java
@@ -566,7 +566,10 @@ public class UCropActivity extends AppCompatActivity {
 
     private void setScaleText(float scale) {
         if (mTextViewScalePercent != null) {
-            mTextViewScalePercent.setText(String.format(Locale.getDefault(), "%d%%", (int) (scale * 100)));
+            float initialScale = mGestureCropImageView.getInitialMinScale();
+            mTextViewScalePercent.setText(
+                String.format(Locale.getDefault(), "%.2f%%", (scale/ initialScale * 100))
+            );
         }
     }
 

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCropFragment.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCropFragment.java
@@ -449,7 +449,10 @@ public class UCropFragment extends Fragment {
 
     private void setScaleText(float scale) {
         if (mTextViewScalePercent != null) {
-            mTextViewScalePercent.setText(String.format(Locale.getDefault(), "%d%%", (int) (scale * 100)));
+            float initialScale = mGestureCropImageView.getInitialMinScale();
+            mTextViewScalePercent.setText(
+                String.format(Locale.getDefault(), "%.2f%%", (scale/ initialScale * 100))
+            );
         }
     }
 

--- a/ucrop/src/main/java/com/yalantis/ucrop/view/CropImageView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/CropImageView.java
@@ -51,6 +51,7 @@ public class CropImageView extends TransformImageView {
     private Runnable mWrapCropBoundsRunnable, mZoomImageToPositionRunnable = null;
 
     private float mMaxScale, mMinScale;
+    private float mInitialMinScale;
     private int mMaxResultImageSizeX = 0, mMaxResultImageSizeY = 0;
     private long mImageToWrapCropBoundsAnimDuration = DEFAULT_IMAGE_TO_CROP_BOUNDS_ANIM_DURATION;
 
@@ -107,6 +108,13 @@ public class CropImageView extends TransformImageView {
      */
     public float getTargetAspectRatio() {
         return mTargetAspectRatio;
+    }
+
+    /**
+     * @return - initial scale value for current image and crop ratio
+     */
+    public float getInitialMinScale() {
+        return mInitialMinScale;
     }
 
     /**
@@ -485,13 +493,13 @@ public class CropImageView extends TransformImageView {
         float widthScale = mCropRect.width() / drawableWidth;
         float heightScale = mCropRect.height() / drawableHeight;
 
-        float initialMinScale = Math.max(widthScale, heightScale);
+        mInitialMinScale = Math.max(widthScale, heightScale);
 
-        float tw = (cropRectWidth - drawableWidth * initialMinScale) / 2.0f + mCropRect.left;
-        float th = (cropRectHeight - drawableHeight * initialMinScale) / 2.0f + mCropRect.top;
+        float tw = (cropRectWidth - drawableWidth * mInitialMinScale) / 2.0f + mCropRect.left;
+        float th = (cropRectHeight - drawableHeight * mInitialMinScale) / 2.0f + mCropRect.top;
 
         mCurrentImageMatrix.reset();
-        mCurrentImageMatrix.postScale(initialMinScale, initialMinScale);
+        mCurrentImageMatrix.postScale(mInitialMinScale, mInitialMinScale);
         mCurrentImageMatrix.postTranslate(tw, th);
         setImageMatrix(mCurrentImageMatrix);
     }

--- a/ucrop/src/main/java/com/yalantis/ucrop/view/CropImageView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/CropImageView.java
@@ -114,7 +114,7 @@ public class CropImageView extends TransformImageView {
      * @return - initial scale value for current image and crop ratio
      */
     public float getInitialMinScale() {
-        return mInitialMinScale;
+        return mInitialMinScale != 0 ? mInitialMinScale : 1;
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2132

This PR fixes the scale "display" text such that it displays the scale in which the image is going to be saved.

![scale](https://user-images.githubusercontent.com/1405144/98327534-bea9c380-2019-11eb-8cfe-17aa43486aaf.gif)

### To test

Code changes were already reviewed [here](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2132#issuecomment-623371149). I've just re-created a PR on this fork.

1. Launch app
2. Choose a random image to edit
3. Go to scale tab
4. Slide the scale wheel
5. Notice that the scale text is displayed correctly.
